### PR TITLE
fix(rss): drop removed .Site.Author refs for Hugo 0.160+

### DIFF
--- a/themes/bl4og/layouts/_default/rss.xml
+++ b/themes/bl4og/layouts/_default/rss.xml
@@ -17,9 +17,7 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{- with .OutputFormats.Get "RSS" -}}
@@ -30,7 +28,6 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
       <content>{{ .Content | html }}</content>


### PR DESCRIPTION
## Problem
`main` broken: Hugo 0.160+ removed the `.Site.Author` map. `themes/bl4og/layouts/_default/rss.xml` referenced `.Site.Author.email` / `.Site.Author.name`, failing the build.

## Fix
Remove the dead `.Site.Author.*` references. No `author` is configured in `hugo.yaml`, so the `managingEditor`, `webMaster`, and per-item `<author>` blocks rendered nothing anyway — pure dead code now that the API is gone.

## Verify
- [ ] CI Hugo build passes (no local hugo to build here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)